### PR TITLE
Fix broken zkillboard links in the killmail table

### DIFF
--- a/src/main/webapp/app/home/killmail-table/killmail-table.component.html
+++ b/src/main/webapp/app/home/killmail-table/killmail-table.component.html
@@ -16,7 +16,7 @@
                 <th>Victim Alliance</th>
             </tr>
             <tr *ngFor="let killmail of killmails">
-                <td><a target="_blank" href="https://zkillboard.com/kill/{{killmail.killmailId}}"><img src="https://image.eveonline.com/Type/{{killmail.shipTypeId}}_32.png" />
+                <td><a target="_blank" href="https://zkillboard.com/kill/{{killmail.killmailId}}/"><img src="https://image.eveonline.com/Type/{{killmail.shipTypeId}}_32.png" />
                     <span *ngIf="killmail.victimName" class="d-none d-sm-inline-block"> {{killmail.victimName}}</span>
                     <span *ngIf="!killmail.victimName" class="d-none d-sm-inline-block"> {{killmail.killmailId}}</span>
                 </a></td>


### PR DESCRIPTION
The links in the killmail table are missing a trailing `/`, which is required by the current version of zkillboard. This PR adds that missing `/`.